### PR TITLE
[fix] markdown rendering fix

### DIFF
--- a/src/ui/markdown.c
+++ b/src/ui/markdown.c
@@ -356,6 +356,8 @@ unsigned markdown_render_line_bg(WINDOW *win, int row, int start_col, int width,
   if (!text || text[0] == '\0')
     return initial_style;
 
+  wattrset(win, A_NORMAL);
+
   RenderCtx ctx = {.win = win,
                    .row = row,
                    .start_col = start_col,


### PR DESCRIPTION
# Fix Markdown Rendering Window Attributes

## Overview

This PR fixes a rendering issue in the markdown rendering function where window attributes from previous rendering operations could leak into subsequent renders, causing inconsistent text styling.

## Problem

The `markdown_render_line_bg` function did not reset window attributes to their default state before starting a new render operation. This could cause attributes (like bold, italic, colors, etc.) from previous rendering calls to persist and affect the current render, leading to incorrect text styling.

## Solution

Added `wattrset(win, A_NORMAL)` at the beginning of the rendering function to ensure the window attributes are reset to normal before processing the text. This guarantees a clean slate for each render operation.

## Changes

### Modified Files
- `src/ui/markdown.c` - Added window attribute reset in `markdown_render_line_bg` function

### Code Change
```c
if (!text || text[0] == '\0')
  return initial_style;

wattrset(win, A_NORMAL);  // Reset attributes before rendering

RenderCtx ctx = {.win = win, ...};
```

## Impact

- **Consistency**: Ensures each markdown line is rendered with the correct attributes, regardless of previous rendering state
- **Reliability**: Prevents attribute leakage between different markdown rendering calls
- **Correctness**: Fixes potential visual bugs where text could appear with incorrect styling

## Technical Details

The `wattrset()` function sets the window's current attributes to the specified value. By setting it to `A_NORMAL` at the start of each render, we ensure that:
1. No leftover attributes from previous operations affect the current render
2. The rendering context starts with a clean attribute state
3. Attributes are then properly applied based on the markdown content being rendered

This is a defensive programming practice that ensures predictable rendering behavior in ncurses-based terminal UIs.

